### PR TITLE
Add bilingual support with Spanish default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>World App Technologies | AI Innovation for Every Enterprise</title>
+    <title>World App Technologies | Innovación de IA para cada empresa</title>
     <meta
       name="description"
-      content="World App Technologies delivers bespoke AI solutions that accelerate transformation for modern enterprises."
+      content="World App Technologies ofrece soluciones de IA a medida que aceleran la transformación de las empresas modernas."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -25,29 +25,37 @@
             <span class="logo-mark" aria-hidden="true">◎</span>
             <span class="logo-text">World App Technologies</span>
           </div>
-          <nav class="main-nav" aria-label="Primary navigation">
+          <nav class="main-nav" aria-label="Navegación principal" data-i18n-aria-label="nav.primaryAria">
             <ul>
-              <li><a href="#solutions">Solutions</a></li>
-              <li><a href="#platform">Platform</a></li>
-              <li><a href="#approach">Approach</a></li>
-              <li><a href="#insights">Insights</a></li>
-              <li><a href="#contact">Contact</a></li>
+              <li><a href="#solutions" data-i18n="nav.solutions">Soluciones</a></li>
+              <li><a href="#platform" data-i18n="nav.platform">Plataforma</a></li>
+              <li><a href="#approach" data-i18n="nav.approach">Enfoque</a></li>
+              <li><a href="#insights" data-i18n="nav.insights">Ideas</a></li>
+              <li><a href="#contact" data-i18n="nav.contact">Contacto</a></li>
             </ul>
           </nav>
-          <button class="ghost-button" type="button">Client Portal</button>
+          <div class="language-switcher" role="group" aria-label="Selector de idioma" data-i18n-aria-label="language.selectorAria">
+            <button type="button" class="language-button active" data-language="es" data-i18n="language.spanish" aria-pressed="true">
+              Español
+            </button>
+            <button type="button" class="language-button" data-language="en" data-i18n="language.english" aria-pressed="false">
+              Inglés
+            </button>
+          </div>
+          <button class="ghost-button" type="button" data-i18n="nav.portal">Portal de clientes</button>
           <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">
-            <span class="sr-only">Toggle navigation</span>
+            <span class="sr-only" data-i18n="nav.menuToggle">Mostrar u ocultar navegación</span>
             <span class="menu-icon"></span>
           </button>
         </div>
-        <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+        <nav class="mobile-nav" id="mobile-nav" aria-label="Navegación móvil" data-i18n-aria-label="nav.mobileAria">
           <ul>
-            <li><a href="#solutions">Solutions</a></li>
-            <li><a href="#platform">Platform</a></li>
-            <li><a href="#approach">Approach</a></li>
-            <li><a href="#insights">Insights</a></li>
-            <li><a href="#contact">Contact</a></li>
-            <li><a class="ghost-link" href="#contact">Client Portal</a></li>
+            <li><a href="#solutions" data-i18n="nav.solutions">Soluciones</a></li>
+            <li><a href="#platform" data-i18n="nav.platform">Plataforma</a></li>
+            <li><a href="#approach" data-i18n="nav.approach">Enfoque</a></li>
+            <li><a href="#insights" data-i18n="nav.insights">Ideas</a></li>
+            <li><a href="#contact" data-i18n="nav.contact">Contacto</a></li>
+            <li><a class="ghost-link" href="#contact" data-i18n="nav.portal">Portal de clientes</a></li>
           </ul>
         </nav>
       </header>
@@ -56,29 +64,29 @@
         <section class="hero" id="hero">
           <div class="container">
             <div class="hero-content">
-              <div class="eyebrow">Trusted AI partner for ambitious teams</div>
-              <h1>
-                Intelligence engineered to accelerate your next era of growth.
+              <div class="eyebrow" data-i18n="hero.eyebrow">Socio de IA de confianza para equipos ambiciosos</div>
+              <h1 data-i18n="hero.heading">
+                Inteligencia diseñada para acelerar su próxima era de crecimiento.
               </h1>
-              <p>
-                World App Technologies architects responsible AI platforms that move beyond experimentation. From hyper-local intelligence to global cloud deployments, we design, build, and scale solutions that unlock measurable value.
+              <p data-i18n="hero.paragraph">
+                World App Technologies diseña plataformas de IA responsable que van más allá de la experimentación. Desde inteligencia híper local hasta despliegues globales en la nube, diseñamos, construimos y escalamos soluciones que desbloquean valor medible.
               </p>
               <div class="cta-group">
-                <a class="primary-button" href="#contact">Schedule a strategy session</a>
-                <a class="secondary-button" href="#solutions">Explore capabilities</a>
+                <a class="primary-button" href="#contact" data-i18n="hero.ctaPrimary">Agendar una sesión estratégica</a>
+                <a class="secondary-button" href="#solutions" data-i18n="hero.ctaSecondary">Explorar capacidades</a>
               </div>
               <div class="hero-stats">
                 <div>
                   <span class="stat-value">98%</span>
-                  <span class="stat-label">Client retention across enterprise engagements</span>
+                  <span class="stat-label" data-i18n="hero.stat1Label">Retención de clientes en compromisos empresariales</span>
                 </div>
                 <div>
                   <span class="stat-value">12x</span>
-                  <span class="stat-label">Average automation ROI in the first year</span>
+                  <span class="stat-label" data-i18n="hero.stat2Label">ROI promedio de automatización en el primer año</span>
                 </div>
                 <div>
                   <span class="stat-value">40+</span>
-                  <span class="stat-label">Specialized AI experts in product, research, and ops</span>
+                  <span class="stat-label" data-i18n="hero.stat3Label">Expertos en IA especializados en producto, investigación y operaciones</span>
                 </div>
               </div>
             </div>
@@ -86,59 +94,59 @@
               <div class="orb orb-1"></div>
               <div class="orb orb-2"></div>
               <div class="mesh-card">
-                <h2>Unified AI Fabric</h2>
-                <p>Converged insights across devices, clouds, and ecosystems.</p>
+                <h2 data-i18n="hero.mesh.title">Tejido de IA unificado</h2>
+                <p data-i18n="hero.mesh.paragraph">Información convergente en dispositivos, nubes y ecosistemas.</p>
                 <ul>
-                  <li>Adaptive knowledge graph</li>
-                  <li>Real-time compliance guardrails</li>
-                  <li>Extensible SDK for your teams</li>
+                  <li data-i18n="hero.mesh.item1">Grafo de conocimiento adaptable</li>
+                  <li data-i18n="hero.mesh.item2">Barreras de cumplimiento en tiempo real</li>
+                  <li data-i18n="hero.mesh.item3">SDK extensible para sus equipos</li>
                 </ul>
               </div>
             </div>
           </div>
         </section>
 
-        <section class="ticker" aria-label="Client highlights">
+        <section class="ticker" aria-label="Casos destacados de clientes" data-i18n-aria-label="nav.tickerAria">
           <div class="ticker-track">
-            <span>Fortune 500 Retail</span>
-            <span>Digital Native Unicorns</span>
-            <span>Smart Cities Initiatives</span>
-            <span>Healthcare Innovators</span>
-            <span>Logistics Networks</span>
-            <span>Financial Services Leaders</span>
-            <span>Next-Gen Manufacturing</span>
+            <span data-i18n="ticker.item1">Retail Fortune 500</span>
+            <span data-i18n="ticker.item2">Unicornios digitales nativos</span>
+            <span data-i18n="ticker.item3">Iniciativas de ciudades inteligentes</span>
+            <span data-i18n="ticker.item4">Innovadores en salud</span>
+            <span data-i18n="ticker.item5">Redes logísticas</span>
+            <span data-i18n="ticker.item6">Líderes en servicios financieros</span>
+            <span data-i18n="ticker.item7">Manufactura de próxima generación</span>
           </div>
         </section>
 
         <section class="section" id="solutions">
           <div class="container">
             <div class="section-heading">
-              <div class="eyebrow">Solutions</div>
-              <h2>Precision-built intelligence for every stage of your AI journey</h2>
-              <p>
-                Our teams partner from discovery to deployment, aligning AI investments with measurable business outcomes and ethical frameworks.
+              <div class="eyebrow" data-i18n="solutions.eyebrow">Soluciones</div>
+              <h2 data-i18n="solutions.heading">Inteligencia de precisión para cada etapa de su viaje de IA</h2>
+              <p data-i18n="solutions.paragraph">
+                Nuestros equipos acompañan desde el descubrimiento hasta el despliegue, alineando las inversiones en IA con resultados comerciales medibles y marcos éticos.
               </p>
             </div>
             <div class="card-grid three">
               <article class="card">
                 <div class="card-icon">⚡</div>
-                <h3>AI Strategy &amp; Advisory</h3>
-                <p>
-                  Translate ambition into actionable roadmaps with executive workshops, industry benchmarking, and opportunity analysis tailored to your organization.
+                <h3 data-i18n="solutions.card1.title">Estrategia y asesoría en IA</h3>
+                <p data-i18n="solutions.card1.text">
+                  Traduce la ambición en hojas de ruta accionables con talleres ejecutivos, análisis comparativos del sector y evaluación de oportunidades adaptada a su organización.
                 </p>
               </article>
               <article class="card">
                 <div class="card-icon">☁️</div>
-                <h3>Cloud AI Platforms</h3>
-                <p>
-                  Architect cloud-native systems optimized for security, scalability, and interoperability. We integrate seamlessly with AWS, Azure, GCP, and sovereign clouds.
+                <h3 data-i18n="solutions.card2.title">Plataformas de IA en la nube</h3>
+                <p data-i18n="solutions.card2.text">
+                  Arquitecturas nativas de la nube optimizadas para seguridad, escalabilidad e interoperabilidad. Integramos sin fricciones con AWS, Azure, GCP y nubes soberanas.
                 </p>
               </article>
               <article class="card">
                 <div class="card-icon">📍</div>
-                <h3>Local &amp; Edge Intelligence</h3>
-                <p>
-                  Deploy AI at the edge with resilient, low-latency models powering local operations, IoT networks, and on-premises workloads without compromise.
+                <h3 data-i18n="solutions.card3.title">Inteligencia local y en el borde</h3>
+                <p data-i18n="solutions.card3.text">
+                  Despliegue IA en el borde con modelos resilientes y de baja latencia que impulsan operaciones locales, redes IoT y cargas de trabajo en sitio sin compromisos.
                 </p>
               </article>
             </div>
@@ -149,44 +157,44 @@
           <div class="container split">
             <div>
               <div class="section-heading">
-                <div class="eyebrow">The World App Platform</div>
-                <h2>Accelerate delivery with a modular AI foundation</h2>
-                <p>
-                  Harness a library of reusable accelerators, compliant data pipelines, and governance frameworks designed to get pilots live in weeks—not months.
+                <div class="eyebrow" data-i18n="platform.eyebrow">La plataforma World App</div>
+                <h2 data-i18n="platform.heading">Acelere la entrega con una base modular de IA</h2>
+                <p data-i18n="platform.paragraph">
+                  Aproveche una biblioteca de aceleradores reutilizables, canalizaciones de datos conformes y marcos de gobernanza diseñados para poner pilotos en marcha en semanas, no meses.
                 </p>
               </div>
               <ul class="feature-list">
-                <li>
-                  <strong>Unified control plane.</strong> One dashboard for orchestrating models, data, and guardrails across hybrid infrastructures.
+                <li data-i18n="platform.feature1">
+                  <strong>Plano de control unificado.</strong> Un tablero para orquestar modelos, datos y barreras en infraestructuras híbridas.
                 </li>
-                <li>
-                  <strong>Responsible by design.</strong> Built-in bias mitigation, observability, and human-in-the-loop workflows ensure accountable outcomes.
+                <li data-i18n="platform.feature2">
+                  <strong>Responsable por diseño.</strong> Mitigación de sesgos, observabilidad y flujos con humanos en el circuito incorporados garantizan resultados responsables.
                 </li>
-                <li>
-                  <strong>Developer-first.</strong> SDKs, APIs, and workflow templates empower your teams to iterate quickly and securely.
+                <li data-i18n="platform.feature3">
+                  <strong>Primero para desarrolladores.</strong> SDK, API y plantillas de flujo de trabajo empoderan a sus equipos para iterar con rapidez y seguridad.
                 </li>
               </ul>
-              <a class="text-link" href="#contact">Book a technical deep dive →</a>
+              <a class="text-link" href="#contact" data-i18n="platform.cta">Reservar una sesión técnica →</a>
             </div>
             <div class="platform-panel" aria-hidden="true">
-              <div class="panel-header">Live systems overview</div>
+              <div class="panel-header" data-i18n="platform.panel.header">Resumen de sistemas en vivo</div>
               <div class="panel-body">
                 <div class="signal">
-                  <span class="signal-label">Inference latency</span>
+                  <span class="signal-label" data-i18n="platform.panel.signal1Label">Latencia de inferencia</span>
                   <span class="signal-value">42ms</span>
                   <span class="signal-trend positive">+12%</span>
                 </div>
                 <div class="signal">
-                  <span class="signal-label">Model reliability</span>
+                  <span class="signal-label" data-i18n="platform.panel.signal2Label">Confiabilidad del modelo</span>
                   <span class="signal-value">99.8%</span>
-                  <span class="signal-trend neutral">Stable</span>
+                  <span class="signal-trend neutral" data-i18n="platform.panel.signal2Trend">Estable</span>
                 </div>
                 <div class="signal">
-                  <span class="signal-label">Secure deployments</span>
+                  <span class="signal-label" data-i18n="platform.panel.signal3Label">Despliegues seguros</span>
                   <span class="signal-value">184</span>
                   <span class="signal-trend positive">+28</span>
                 </div>
-                <div class="sparkline" role="img" aria-label="Platform performance trend visualization"></div>
+                <div class="sparkline" role="img" aria-label="Visualización de la tendencia de rendimiento de la plataforma" data-i18n-aria-label="platform.panel.sparklineAria"></div>
               </div>
             </div>
           </div>
@@ -195,28 +203,28 @@
         <section class="section muted" id="insights">
           <div class="container">
             <div class="section-heading">
-              <div class="eyebrow">Impact</div>
-              <h2>Delivering outcomes that compound across the enterprise</h2>
-              <p>
-                From first pilot to scaled transformation, we anchor every engagement in measurable KPIs that matter to your teams.
+              <div class="eyebrow" data-i18n="impact.eyebrow">Impacto</div>
+              <h2 data-i18n="impact.heading">Entregamos resultados que se multiplican en toda la empresa</h2>
+              <p data-i18n="impact.paragraph">
+                Desde el primer piloto hasta la transformación a escala, anclamos cada compromiso en indicadores clave medibles que importan a sus equipos.
               </p>
             </div>
             <div class="metrics-grid">
               <div class="metric">
                 <span class="metric-value">68%</span>
-                <span class="metric-label">Reduction in manual triage time for a national insurer</span>
+                <span class="metric-label" data-i18n="impact.metric1">Reducción del tiempo de triaje manual para un asegurador nacional</span>
               </div>
               <div class="metric">
                 <span class="metric-value">4.7M</span>
-                <span class="metric-label">New customer interactions personalized via local AI assistants</span>
+                <span class="metric-label" data-i18n="impact.metric2">Nuevas interacciones con clientes personalizadas mediante asistentes locales de IA</span>
               </div>
               <div class="metric">
                 <span class="metric-value">21</span>
-                <span class="metric-label">Markets activated with multilingual AI agents in under 90 days</span>
+                <span class="metric-label" data-i18n="impact.metric3">Mercados activados con agentes de IA multilingües en menos de 90 días</span>
               </div>
               <div class="metric">
                 <span class="metric-value">35%</span>
-                <span class="metric-label">Increase in supply-chain resilience through predictive intelligence</span>
+                <span class="metric-label" data-i18n="impact.metric4">Aumento de la resiliencia de la cadena de suministro mediante inteligencia predictiva</span>
               </div>
             </div>
           </div>
@@ -225,37 +233,37 @@
         <section class="section" id="approach">
           <div class="container">
             <div class="section-heading">
-              <div class="eyebrow">Our approach</div>
-              <h2>Guided by rigor, grounded in partnership</h2>
-              <p>
-                We embed cross-functional squads that work alongside your teams to co-create, iterate, and scale with confidence.
+              <div class="eyebrow" data-i18n="approach.eyebrow">Nuestro enfoque</div>
+              <h2 data-i18n="approach.heading">Guiados por el rigor, fundamentados en la colaboración</h2>
+              <p data-i18n="approach.paragraph">
+                Incrustamos escuadrones multifuncionales que trabajan junto a sus equipos para cocrear, iterar y escalar con confianza.
               </p>
             </div>
             <div class="timeline">
               <div class="timeline-item">
                 <div class="timeline-marker">1</div>
                 <div>
-                  <h3>Discover &amp; align</h3>
-                  <p>
-                    Map objectives, data sources, and governance requirements to craft a program blueprint with stakeholder consensus.
+                  <h3 data-i18n="approach.step1.title">Descubrir y alinear</h3>
+                  <p data-i18n="approach.step1.text">
+                    Mapeamos objetivos, fuentes de datos y requisitos de gobernanza para diseñar un plan maestro con consenso de las partes interesadas.
                   </p>
                 </div>
               </div>
               <div class="timeline-item">
                 <div class="timeline-marker">2</div>
                 <div>
-                  <h3>Design &amp; validate</h3>
-                  <p>
-                    Rapid prototyping with real data, rigorous evaluation, and transparent reporting to fine-tune performance.
+                  <h3 data-i18n="approach.step2.title">Diseñar y validar</h3>
+                  <p data-i18n="approach.step2.text">
+                    Prototipos rápidos con datos reales, evaluación rigurosa e informes transparentes para ajustar el desempeño.
                   </p>
                 </div>
               </div>
               <div class="timeline-item">
                 <div class="timeline-marker">3</div>
                 <div>
-                  <h3>Deploy &amp; scale</h3>
-                  <p>
-                    Production-grade deployments with observability, lifecycle management, and enablement for sustained adoption.
+                  <h3 data-i18n="approach.step3.title">Desplegar y escalar</h3>
+                  <p data-i18n="approach.step3.text">
+                    Implementaciones de grado de producción con observabilidad, gestión del ciclo de vida y habilitación para una adopción sostenida.
                   </p>
                 </div>
               </div>
@@ -266,26 +274,26 @@
         <section class="section muted">
           <div class="container testimonials">
             <div class="section-heading">
-              <div class="eyebrow">What partners say</div>
-              <h2>Future-focused teams choose World App Technologies</h2>
+              <div class="eyebrow" data-i18n="testimonials.eyebrow">Lo que dicen nuestros socios</div>
+              <h2 data-i18n="testimonials.heading">Equipos orientados al futuro eligen World App Technologies</h2>
             </div>
             <div class="testimonial-grid">
               <figure class="testimonial">
-                <blockquote>
-                  “World App Technologies transformed our fragmented data into a decision engine that supports every storefront. Their teams felt like an extension of ours.”
+                <blockquote data-i18n="testimonials.quote1">
+                  “World App Technologies transformó nuestros datos fragmentados en un motor de decisiones que respalda cada punto de venta. Sus equipos se sintieron como una extensión del nuestro.”
                 </blockquote>
                 <figcaption>
-                  <span class="name">Chief Digital Officer</span>
-                  <span class="company">Global Retail Group</span>
+                  <span class="name" data-i18n="testimonials.role1">Directora digital</span>
+                  <span class="company" data-i18n="testimonials.company1">Grupo minorista global</span>
                 </figcaption>
               </figure>
               <figure class="testimonial">
-                <blockquote>
-                  “Their responsible AI framework gave our regulators the transparency they needed without slowing innovation. We delivered in record time.”
+                <blockquote data-i18n="testimonials.quote2">
+                  “Su marco de IA responsable brindó a nuestros reguladores la transparencia que necesitaban sin frenar la innovación. Entregamos en tiempo récord.”
                 </blockquote>
                 <figcaption>
-                  <span class="name">Head of Innovation</span>
-                  <span class="company">Fortune 100 Financial Services</span>
+                  <span class="name" data-i18n="testimonials.role2">Director de innovación</span>
+                  <span class="company" data-i18n="testimonials.company2">Servicios financieros Fortune 100</span>
                 </figcaption>
               </figure>
             </div>
@@ -296,48 +304,54 @@
           <div class="container split">
             <div>
               <div class="section-heading">
-                <div class="eyebrow">Let’s build what’s next</div>
-                <h2>Ready to architect your AI advantage?</h2>
-                <p>
-                  Share a bit about your objectives and our consultants will curate a roadmap session tailored to your organization.
+                <div class="eyebrow" data-i18n="contact.eyebrow">Construyamos lo que sigue</div>
+                <h2 data-i18n="contact.heading">¿Listo para diseñar su ventaja competitiva en IA?</h2>
+                <p data-i18n="contact.paragraph">
+                  Comparta un poco sobre sus objetivos y nuestros consultores prepararán una sesión de ruta adaptada a su organización.
                 </p>
                 <div class="contact-details">
-                  <p><strong>Email:</strong> hello@worldapptech.com</p>
-                  <p><strong>HQ:</strong> 230 Market Street, Suite 1800, San Francisco, CA</p>
-                  <p><strong>Global presence:</strong> New York · London · Singapore</p>
+                  <p><strong data-i18n="contact.labelEmail">Correo:</strong> hello@worldapptech.com</p>
+                  <p><strong data-i18n="contact.labelHq">Oficinas centrales:</strong> 230 Market Street, Suite 1800, San Francisco, CA</p>
+                  <p><strong data-i18n="contact.labelGlobal">Presencia global:</strong> Nueva York · Londres · Singapur</p>
                 </div>
               </div>
             </div>
             <form class="contact-form">
               <div class="form-group">
-                <label for="name">Name</label>
+                <label for="name" data-i18n="form.nameLabel">Nombre</label>
                 <input type="text" id="name" name="name" placeholder="Alex Morgan" required />
               </div>
               <div class="form-group">
-                <label for="email">Work email</label>
+                <label for="email" data-i18n="form.emailLabel">Correo laboral</label>
                 <input type="email" id="email" name="email" placeholder="alex@company.com" required />
               </div>
               <div class="form-group">
-                <label for="company">Company</label>
-                <input type="text" id="company" name="company" placeholder="Your organization" />
+                <label for="company" data-i18n="form.companyLabel">Empresa</label>
+                <input type="text" id="company" name="company" placeholder="Su organización" data-i18n-placeholder="form.companyPlaceholder" />
               </div>
               <div class="form-group">
-                <label for="project">Initiative focus</label>
+                <label for="project" data-i18n="form.projectLabel">Enfoque de la iniciativa</label>
                 <select id="project" name="project">
-                  <option>AI strategy alignment</option>
-                  <option>Cloud AI platform</option>
-                  <option>Local/edge intelligence</option>
-                  <option>Responsible AI governance</option>
-                  <option>Other</option>
+                  <option data-i18n="form.option1">Alineación de estrategia de IA</option>
+                  <option data-i18n="form.option2">Plataforma de IA en la nube</option>
+                  <option data-i18n="form.option3">Inteligencia local/en el borde</option>
+                  <option data-i18n="form.option4">Gobernanza responsable de IA</option>
+                  <option data-i18n="form.option5">Otra</option>
                 </select>
               </div>
               <div class="form-group">
-                <label for="message">Tell us more</label>
-                <textarea id="message" name="message" rows="4" placeholder="What outcomes are you targeting?"></textarea>
+                <label for="message" data-i18n="form.messageLabel">Cuéntenos más</label>
+                <textarea
+                  id="message"
+                  name="message"
+                  rows="4"
+                  placeholder="¿Qué resultados está buscando?"
+                  data-i18n-placeholder="form.messagePlaceholder"
+                ></textarea>
               </div>
-              <button class="primary-button" type="submit">Submit inquiry</button>
-              <p class="form-caption">
-                By submitting this form, you agree to our privacy policy and consent to receive communications from World App Technologies.
+              <button class="primary-button" type="submit" data-i18n="form.submit">Enviar consulta</button>
+              <p class="form-caption" data-i18n="form.caption">
+                Al enviar este formulario, acepta nuestra política de privacidad y consiente recibir comunicaciones de World App Technologies.
               </p>
             </form>
           </div>
@@ -351,13 +365,13 @@
             <span class="logo-text">World App Technologies</span>
           </div>
           <div class="footer-links">
-            <a href="#hero">Overview</a>
-            <a href="#solutions">Solutions</a>
-            <a href="#platform">Platform</a>
-            <a href="#approach">Approach</a>
-            <a href="#contact">Contact</a>
+            <a href="#hero" data-i18n="nav.overview">Resumen</a>
+            <a href="#solutions" data-i18n="nav.solutions">Soluciones</a>
+            <a href="#platform" data-i18n="nav.platform">Plataforma</a>
+            <a href="#approach" data-i18n="nav.approach">Enfoque</a>
+            <a href="#contact" data-i18n="nav.contact">Contacto</a>
           </div>
-          <p class="legal">© <span id="current-year"></span> World App Technologies. All rights reserved.</p>
+          <p class="legal" data-i18n="footer.legal">© <span id="current-year"></span> World App Technologies. Todos los derechos reservados.</p>
         </div>
       </footer>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,264 @@
 const menuToggle = document.querySelector('.menu-toggle');
 const mobileNav = document.querySelector('.mobile-nav');
-const currentYearEl = document.getElementById('current-year');
+const currentYear = new Date().getFullYear().toString();
+const languageButtons = document.querySelectorAll('.language-button');
+const textElements = document.querySelectorAll('[data-i18n]');
+const placeholderElements = document.querySelectorAll('[data-i18n-placeholder]');
+const ariaLabelElements = document.querySelectorAll('[data-i18n-aria-label]');
+const metaDescriptionEl = document.querySelector('meta[name="description"]');
+
+const translations = {
+  es: {
+    'meta.title': 'World App Technologies | Innovación de IA para cada empresa',
+    'meta.description':
+      'World App Technologies ofrece soluciones de IA a medida que aceleran la transformación de las empresas modernas.',
+    'nav.primaryAria': 'Navegación principal',
+    'nav.mobileAria': 'Navegación móvil',
+    'nav.tickerAria': 'Casos destacados de clientes',
+    'nav.solutions': 'Soluciones',
+    'nav.platform': 'Plataforma',
+    'nav.approach': 'Enfoque',
+    'nav.insights': 'Ideas',
+    'nav.contact': 'Contacto',
+    'nav.portal': 'Portal de clientes',
+    'nav.overview': 'Resumen',
+    'nav.menuToggle': 'Mostrar u ocultar navegación',
+    'language.selectorAria': 'Selector de idioma',
+    'language.spanish': 'Español',
+    'language.english': 'Inglés',
+    'hero.eyebrow': 'Socio de IA de confianza para equipos ambiciosos',
+    'hero.heading': 'Inteligencia diseñada para acelerar su próxima era de crecimiento.',
+    'hero.paragraph':
+      'World App Technologies diseña plataformas de IA responsable que van más allá de la experimentación. Desde inteligencia híper local hasta despliegues globales en la nube, diseñamos, construimos y escalamos soluciones que desbloquean valor medible.',
+    'hero.ctaPrimary': 'Agendar una sesión estratégica',
+    'hero.ctaSecondary': 'Explorar capacidades',
+    'hero.stat1Label': 'Retención de clientes en compromisos empresariales',
+    'hero.stat2Label': 'ROI promedio de automatización en el primer año',
+    'hero.stat3Label': 'Expertos en IA especializados en producto, investigación y operaciones',
+    'hero.mesh.title': 'Tejido de IA unificado',
+    'hero.mesh.paragraph': 'Información convergente en dispositivos, nubes y ecosistemas.',
+    'hero.mesh.item1': 'Grafo de conocimiento adaptable',
+    'hero.mesh.item2': 'Barreras de cumplimiento en tiempo real',
+    'hero.mesh.item3': 'SDK extensible para sus equipos',
+    'ticker.item1': 'Retail Fortune 500',
+    'ticker.item2': 'Unicornios digitales nativos',
+    'ticker.item3': 'Iniciativas de ciudades inteligentes',
+    'ticker.item4': 'Innovadores en salud',
+    'ticker.item5': 'Redes logísticas',
+    'ticker.item6': 'Líderes en servicios financieros',
+    'ticker.item7': 'Manufactura de próxima generación',
+    'solutions.eyebrow': 'Soluciones',
+    'solutions.heading': 'Inteligencia de precisión para cada etapa de su viaje de IA',
+    'solutions.paragraph':
+      'Nuestros equipos acompañan desde el descubrimiento hasta el despliegue, alineando las inversiones en IA con resultados comerciales medibles y marcos éticos.',
+    'solutions.card1.title': 'Estrategia y asesoría en IA',
+    'solutions.card1.text':
+      'Traduce la ambición en hojas de ruta accionables con talleres ejecutivos, análisis comparativos del sector y evaluación de oportunidades adaptada a su organización.',
+    'solutions.card2.title': 'Plataformas de IA en la nube',
+    'solutions.card2.text':
+      'Arquitecturas nativas de la nube optimizadas para seguridad, escalabilidad e interoperabilidad. Integramos sin fricciones con AWS, Azure, GCP y nubes soberanas.',
+    'solutions.card3.title': 'Inteligencia local y en el borde',
+    'solutions.card3.text':
+      'Despliegue IA en el borde con modelos resilientes y de baja latencia que impulsan operaciones locales, redes IoT y cargas de trabajo en sitio sin compromisos.',
+    'platform.eyebrow': 'La plataforma World App',
+    'platform.heading': 'Acelere la entrega con una base modular de IA',
+    'platform.paragraph':
+      'Aproveche una biblioteca de aceleradores reutilizables, canalizaciones de datos conformes y marcos de gobernanza diseñados para poner pilotos en marcha en semanas, no meses.',
+    'platform.feature1':
+      '<strong>Plano de control unificado.</strong> Un tablero para orquestar modelos, datos y barreras en infraestructuras híbridas.',
+    'platform.feature2':
+      '<strong>Responsable por diseño.</strong> Mitigación de sesgos, observabilidad y flujos con humanos en el circuito incorporados garantizan resultados responsables.',
+    'platform.feature3':
+      '<strong>Primero para desarrolladores.</strong> SDK, API y plantillas de flujo de trabajo empoderan a sus equipos para iterar con rapidez y seguridad.',
+    'platform.cta': 'Reservar una sesión técnica →',
+    'platform.panel.header': 'Resumen de sistemas en vivo',
+    'platform.panel.signal1Label': 'Latencia de inferencia',
+    'platform.panel.signal2Label': 'Confiabilidad del modelo',
+    'platform.panel.signal2Trend': 'Estable',
+    'platform.panel.signal3Label': 'Despliegues seguros',
+    'platform.panel.sparklineAria': 'Visualización de la tendencia de rendimiento de la plataforma',
+    'impact.eyebrow': 'Impacto',
+    'impact.heading': 'Entregamos resultados que se multiplican en toda la empresa',
+    'impact.paragraph':
+      'Desde el primer piloto hasta la transformación a escala, anclamos cada compromiso en indicadores clave medibles que importan a sus equipos.',
+    'impact.metric1': 'Reducción del tiempo de triaje manual para un asegurador nacional',
+    'impact.metric2': 'Nuevas interacciones con clientes personalizadas mediante asistentes locales de IA',
+    'impact.metric3': 'Mercados activados con agentes de IA multilingües en menos de 90 días',
+    'impact.metric4': 'Aumento de la resiliencia de la cadena de suministro mediante inteligencia predictiva',
+    'approach.eyebrow': 'Nuestro enfoque',
+    'approach.heading': 'Guiados por el rigor, fundamentados en la colaboración',
+    'approach.paragraph':
+      'Incrustamos escuadrones multifuncionales que trabajan junto a sus equipos para cocrear, iterar y escalar con confianza.',
+    'approach.step1.title': 'Descubrir y alinear',
+    'approach.step1.text':
+      'Mapeamos objetivos, fuentes de datos y requisitos de gobernanza para diseñar un plan maestro con consenso de las partes interesadas.',
+    'approach.step2.title': 'Diseñar y validar',
+    'approach.step2.text':
+      'Prototipos rápidos con datos reales, evaluación rigurosa e informes transparentes para ajustar el desempeño.',
+    'approach.step3.title': 'Desplegar y escalar',
+    'approach.step3.text':
+      'Implementaciones de grado de producción con observabilidad, gestión del ciclo de vida y habilitación para una adopción sostenida.',
+    'testimonials.eyebrow': 'Lo que dicen nuestros socios',
+    'testimonials.heading': 'Equipos orientados al futuro eligen World App Technologies',
+    'testimonials.quote1':
+      '“World App Technologies transformó nuestros datos fragmentados en un motor de decisiones que respalda cada punto de venta. Sus equipos se sintieron como una extensión del nuestro.”',
+    'testimonials.role1': 'Directora digital',
+    'testimonials.company1': 'Grupo minorista global',
+    'testimonials.quote2':
+      '“Su marco de IA responsable brindó a nuestros reguladores la transparencia que necesitaban sin frenar la innovación. Entregamos en tiempo récord.”',
+    'testimonials.role2': 'Director de innovación',
+    'testimonials.company2': 'Servicios financieros Fortune 100',
+    'contact.eyebrow': 'Construyamos lo que sigue',
+    'contact.heading': '¿Listo para diseñar su ventaja competitiva en IA?',
+    'contact.paragraph':
+      'Comparta un poco sobre sus objetivos y nuestros consultores prepararán una sesión de ruta adaptada a su organización.',
+    'contact.labelEmail': 'Correo:',
+    'contact.labelHq': 'Oficinas centrales:',
+    'contact.labelGlobal': 'Presencia global:',
+    'form.nameLabel': 'Nombre',
+    'form.emailLabel': 'Correo laboral',
+    'form.companyLabel': 'Empresa',
+    'form.companyPlaceholder': 'Su organización',
+    'form.projectLabel': 'Enfoque de la iniciativa',
+    'form.option1': 'Alineación de estrategia de IA',
+    'form.option2': 'Plataforma de IA en la nube',
+    'form.option3': 'Inteligencia local/en el borde',
+    'form.option4': 'Gobernanza responsable de IA',
+    'form.option5': 'Otra',
+    'form.messageLabel': 'Cuéntenos más',
+    'form.messagePlaceholder': '¿Qué resultados está buscando?',
+    'form.submit': 'Enviar consulta',
+    'form.caption':
+      'Al enviar este formulario, acepta nuestra política de privacidad y consiente recibir comunicaciones de World App Technologies.',
+    'footer.legal': '© <span id="current-year"></span> World App Technologies. Todos los derechos reservados.'
+  },
+  en: {
+    'meta.title': 'World App Technologies | AI Innovation for Every Enterprise',
+    'meta.description':
+      'World App Technologies delivers bespoke AI solutions that accelerate transformation for modern enterprises.',
+    'nav.primaryAria': 'Primary navigation',
+    'nav.mobileAria': 'Mobile navigation',
+    'nav.tickerAria': 'Client highlights',
+    'nav.solutions': 'Solutions',
+    'nav.platform': 'Platform',
+    'nav.approach': 'Approach',
+    'nav.insights': 'Insights',
+    'nav.contact': 'Contact',
+    'nav.portal': 'Client Portal',
+    'nav.overview': 'Overview',
+    'nav.menuToggle': 'Toggle navigation',
+    'language.selectorAria': 'Language selector',
+    'language.spanish': 'Spanish',
+    'language.english': 'English',
+    'hero.eyebrow': 'Trusted AI partner for ambitious teams',
+    'hero.heading': 'Intelligence engineered to accelerate your next era of growth.',
+    'hero.paragraph':
+      'World App Technologies architects responsible AI platforms that move beyond experimentation. From hyper-local intelligence to global cloud deployments, we design, build, and scale solutions that unlock measurable value.',
+    'hero.ctaPrimary': 'Schedule a strategy session',
+    'hero.ctaSecondary': 'Explore capabilities',
+    'hero.stat1Label': 'Client retention across enterprise engagements',
+    'hero.stat2Label': 'Average automation ROI in the first year',
+    'hero.stat3Label': 'Specialized AI experts in product, research, and ops',
+    'hero.mesh.title': 'Unified AI Fabric',
+    'hero.mesh.paragraph': 'Converged insights across devices, clouds, and ecosystems.',
+    'hero.mesh.item1': 'Adaptive knowledge graph',
+    'hero.mesh.item2': 'Real-time compliance guardrails',
+    'hero.mesh.item3': 'Extensible SDK for your teams',
+    'ticker.item1': 'Fortune 500 Retail',
+    'ticker.item2': 'Digital Native Unicorns',
+    'ticker.item3': 'Smart Cities Initiatives',
+    'ticker.item4': 'Healthcare Innovators',
+    'ticker.item5': 'Logistics Networks',
+    'ticker.item6': 'Financial Services Leaders',
+    'ticker.item7': 'Next-Gen Manufacturing',
+    'solutions.eyebrow': 'Solutions',
+    'solutions.heading': 'Precision-built intelligence for every stage of your AI journey',
+    'solutions.paragraph':
+      'Our teams partner from discovery to deployment, aligning AI investments with measurable business outcomes and ethical frameworks.',
+    'solutions.card1.title': 'AI Strategy & Advisory',
+    'solutions.card1.text':
+      'Translate ambition into actionable roadmaps with executive workshops, industry benchmarking, and opportunity analysis tailored to your organization.',
+    'solutions.card2.title': 'Cloud AI Platforms',
+    'solutions.card2.text':
+      'Architect cloud-native systems optimized for security, scalability, and interoperability. We integrate seamlessly with AWS, Azure, GCP, and sovereign clouds.',
+    'solutions.card3.title': 'Local & Edge Intelligence',
+    'solutions.card3.text':
+      'Deploy AI at the edge with resilient, low-latency models powering local operations, IoT networks, and on-premises workloads without compromise.',
+    'platform.eyebrow': 'The World App Platform',
+    'platform.heading': 'Accelerate delivery with a modular AI foundation',
+    'platform.paragraph':
+      'Harness a library of reusable accelerators, compliant data pipelines, and governance frameworks designed to get pilots live in weeks—not months.',
+    'platform.feature1':
+      '<strong>Unified control plane.</strong> One dashboard for orchestrating models, data, and guardrails across hybrid infrastructures.',
+    'platform.feature2':
+      '<strong>Responsible by design.</strong> Built-in bias mitigation, observability, and human-in-the-loop workflows ensure accountable outcomes.',
+    'platform.feature3':
+      '<strong>Developer-first.</strong> SDKs, APIs, and workflow templates empower your teams to iterate quickly and securely.',
+    'platform.cta': 'Book a technical deep dive →',
+    'platform.panel.header': 'Live systems overview',
+    'platform.panel.signal1Label': 'Inference latency',
+    'platform.panel.signal2Label': 'Model reliability',
+    'platform.panel.signal2Trend': 'Stable',
+    'platform.panel.signal3Label': 'Secure deployments',
+    'platform.panel.sparklineAria': 'Platform performance trend visualization',
+    'impact.eyebrow': 'Impact',
+    'impact.heading': 'Delivering outcomes that compound across the enterprise',
+    'impact.paragraph':
+      'From first pilot to scaled transformation, we anchor every engagement in measurable KPIs that matter to your teams.',
+    'impact.metric1': 'Reduction in manual triage time for a national insurer',
+    'impact.metric2': 'New customer interactions personalized via local AI assistants',
+    'impact.metric3': 'Markets activated with multilingual AI agents in under 90 days',
+    'impact.metric4': 'Increase in supply-chain resilience through predictive intelligence',
+    'approach.eyebrow': 'Our approach',
+    'approach.heading': 'Guided by rigor, grounded in partnership',
+    'approach.paragraph':
+      'We embed cross-functional squads that work alongside your teams to co-create, iterate, and scale with confidence.',
+    'approach.step1.title': 'Discover & align',
+    'approach.step1.text':
+      'Map objectives, data sources, and governance requirements to craft a program blueprint with stakeholder consensus.',
+    'approach.step2.title': 'Design & validate',
+    'approach.step2.text':
+      'Rapid prototyping with real data, rigorous evaluation, and transparent reporting to fine-tune performance.',
+    'approach.step3.title': 'Deploy & scale',
+    'approach.step3.text':
+      'Production-grade deployments with observability, lifecycle management, and enablement for sustained adoption.',
+    'testimonials.eyebrow': 'What partners say',
+    'testimonials.heading': 'Future-focused teams choose World App Technologies',
+    'testimonials.quote1':
+      '“World App Technologies transformed our fragmented data into a decision engine that supports every storefront. Their teams felt like an extension of ours.”',
+    'testimonials.role1': 'Chief Digital Officer',
+    'testimonials.company1': 'Global Retail Group',
+    'testimonials.quote2':
+      '“Their responsible AI framework gave our regulators the transparency they needed without slowing innovation. We delivered in record time.”',
+    'testimonials.role2': 'Head of Innovation',
+    'testimonials.company2': 'Fortune 100 Financial Services',
+    'contact.eyebrow': "Let's build what's next",
+    'contact.heading': 'Ready to architect your AI advantage?',
+    'contact.paragraph':
+      'Share a bit about your objectives and our consultants will curate a roadmap session tailored to your organization.',
+    'contact.labelEmail': 'Email:',
+    'contact.labelHq': 'HQ:',
+    'contact.labelGlobal': 'Global presence:',
+    'form.nameLabel': 'Name',
+    'form.emailLabel': 'Work email',
+    'form.companyLabel': 'Company',
+    'form.companyPlaceholder': 'Your organization',
+    'form.projectLabel': 'Initiative focus',
+    'form.option1': 'AI strategy alignment',
+    'form.option2': 'Cloud AI platform',
+    'form.option3': 'Local/edge intelligence',
+    'form.option4': 'Responsible AI governance',
+    'form.option5': 'Other',
+    'form.messageLabel': 'Tell us more',
+    'form.messagePlaceholder': 'What outcomes are you targeting?',
+    'form.submit': 'Submit inquiry',
+    'form.caption':
+      'By submitting this form, you agree to our privacy policy and consent to receive communications from World App Technologies.',
+    'footer.legal': '© <span id="current-year"></span> World App Technologies. All rights reserved.'
+  }
+};
+
+let currentLanguage = 'es';
 
 if (menuToggle && mobileNav) {
   menuToggle.addEventListener('click', () => {
@@ -17,6 +275,82 @@ if (menuToggle && mobileNav) {
   });
 }
 
-if (currentYearEl) {
-  currentYearEl.textContent = new Date().getFullYear().toString();
+const updateCurrentYear = () => {
+  const yearElement = document.getElementById('current-year');
+
+  if (yearElement) {
+    yearElement.textContent = currentYear;
+  }
+};
+
+function applyLanguage(language) {
+  const languageTranslations = translations[language];
+
+  if (!languageTranslations) {
+    return;
+  }
+
+  currentLanguage = language;
+  document.documentElement.setAttribute('lang', language);
+
+  textElements.forEach((element) => {
+    const key = element.dataset.i18n;
+    const translation = languageTranslations[key];
+
+    if (translation) {
+      element.innerHTML = translation;
+    }
+  });
+
+  placeholderElements.forEach((element) => {
+    const key = element.dataset.i18nPlaceholder;
+    const translation = languageTranslations[key];
+
+    if (translation) {
+      element.setAttribute('placeholder', translation);
+    }
+  });
+
+  ariaLabelElements.forEach((element) => {
+    const key = element.dataset.i18nAriaLabel;
+    const translation = languageTranslations[key];
+
+    if (translation) {
+      element.setAttribute('aria-label', translation);
+    }
+  });
+
+  if (metaDescriptionEl) {
+    const description = languageTranslations['meta.description'];
+
+    if (description) {
+      metaDescriptionEl.setAttribute('content', description);
+    }
+  }
+
+  const title = languageTranslations['meta.title'];
+
+  if (title) {
+    document.title = title;
+  }
+
+  languageButtons.forEach((button) => {
+    const isActive = button.dataset.language === language;
+    button.classList.toggle('active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+
+  updateCurrentYear();
 }
+
+languageButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const selectedLanguage = button.dataset.language;
+
+    if (selectedLanguage && selectedLanguage !== currentLanguage) {
+      applyLanguage(selectedLanguage);
+    }
+  });
+});
+
+applyLanguage(currentLanguage);

--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,38 @@ body::before {
   padding: 0;
 }
 
+.language-switcher {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.language-button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+}
+
+.language-button:hover,
+.language-button:focus {
+  color: var(--text-primary);
+  border-color: var(--accent);
+  background: rgba(88, 210, 255, 0.14);
+  outline: none;
+}
+
+.language-button.active {
+  color: var(--text-primary);
+  border-color: var(--accent-strong);
+  background: rgba(122, 108, 255, 0.18);
+}
+
 .main-nav a,
 .mobile-nav a,
 .footer-links a {


### PR DESCRIPTION
## Summary
- translate the marketing site copy into Spanish and annotate content with i18n keys
- add an ES/EN language toggle that updates document text, metadata, and accessibility labels
- style the language selector to match the existing header design

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ceea1c7050832b83aeb29f03c0c9cd